### PR TITLE
Default password is not showing in dialog for Git repositories UI

### DIFF
--- a/meveo-admin-web/src/main/java/org/meveo/admin/action/storage/GitRepositoryBean.java
+++ b/meveo-admin-web/src/main/java/org/meveo/admin/action/storage/GitRepositoryBean.java
@@ -32,6 +32,7 @@ import org.meveo.elresolver.ELException;
 import org.meveo.model.git.GitRepository;
 import org.meveo.model.module.MeveoModule;
 import org.meveo.model.storage.Repository;
+import org.meveo.security.PasswordUtils;
 import org.meveo.service.admin.impl.MeveoModuleService;
 import org.meveo.service.base.local.IPersistenceService;
 import org.meveo.service.git.GitClient;
@@ -134,8 +135,13 @@ public class GitRepositoryBean extends BaseCrudBean<GitRepository, GitRepository
 	public String saveOrUpdateGit() throws BusinessException, ELException {
 
 		if (entity.getId() == null && entity.getRemoteOrigin() != null) {
+			
+			if(this.password.equals(entity.getDefaultRemotePassword())) {
+				password = PasswordUtils.decrypt(entity.getSalt(), password);
+			}
+			
 			try {
-				gitRepositoryService.create(entity, false, this.getUsername(), this.getPassword());
+				gitRepositoryService.create(entity, false, username,password);
 			} catch (Exception e) {
 				return MessagesHelper.error(messages, e);
 			}
@@ -152,7 +158,10 @@ public class GitRepositoryBean extends BaseCrudBean<GitRepository, GitRepository
 
 	public void pushRemote() {
 		try {
-			gitClient.push(entity, this.getUsername(), this.getPassword());
+			if(this.password.equals(entity.getDefaultRemotePassword())) {
+				password = PasswordUtils.decrypt(entity.getSalt(), password);
+			}
+			gitClient.push(entity,username, password);
 			initEntity(entity.getId());
 			messages.info(new BundleKey("messages", "gitRepositories.push.successful"));
 		} catch (Exception e) {
@@ -201,7 +210,10 @@ public class GitRepositoryBean extends BaseCrudBean<GitRepository, GitRepository
 	
 	public void fetchRemote() {
 		try {
-			gitClient.fetch(entity, this.getUsername(), this.getPassword());
+			if(this.password.equals(entity.getDefaultRemotePassword())) {
+				password = PasswordUtils.decrypt(entity.getSalt(), password);
+			}
+			gitClient.fetch(entity, username, password);
 			initEntity(entity.getId());
 			messages.info(new BundleKey("messages", "gitRepositories.pull.successful"));
 		} catch (Exception e) {
@@ -212,7 +224,10 @@ public class GitRepositoryBean extends BaseCrudBean<GitRepository, GitRepository
 
 	public void pullRemote() {
 		try {
-			gitClient.pull(entity, this.getUsername(), this.getPassword());
+			if(this.password.equals(entity.getDefaultRemotePassword())) {
+				password = PasswordUtils.decrypt(entity.getSalt(), password);
+			}
+			gitClient.pull(entity, username, password);
 			initEntity(entity.getId());
 			messages.info(new BundleKey("messages", "gitRepositories.pull.successful"));
 		} catch (Exception e) {
@@ -298,6 +313,9 @@ public class GitRepositoryBean extends BaseCrudBean<GitRepository, GitRepository
 	}
 
 	public String getPassword() {
+		if (entity.getId() != null && entity.getRemoteOrigin() != null) {
+			password = entity.getDefaultRemotePassword();
+		}
 		return password;
 	}
 
@@ -333,6 +351,10 @@ public class GitRepositoryBean extends BaseCrudBean<GitRepository, GitRepository
 	
 	public String installMissingDependencies() {
 		try {
+			
+			if(this.password.equals(entity.getDefaultRemotePassword())) {
+				password = PasswordUtils.decrypt(entity.getSalt(), password);
+			}
 			LinkedHashMap<GitRepository, ModuleDependencyDto> gitRepos = moduleApi.retrieveModuleDependencies(missingDependencies, username, password);
 			
 			this.missingDependencies = new ArrayList<>(gitRepos.values());


### PR DESCRIPTION
 **Issue :**  
 After created a git repository with a remote origin and save a default username and Default Remote Password,
 the default password is not showing in dialog when doing a pull or other, every git operation needs to type this remote password in dialog.
 
 **root cause:**  
 After analysis, I got root cause of this issue. during data insertion time , git password save as encrypt format in db table (git_repository).
 dialog password value related with GitRepositoryBean.password  attribute , but this value is not initialized from db during dialog
 initialization time. as a result, password value is not showing in dialog. that's why need to do type this remote password every time in dialog.
 
 **Solution:**
 After save this default username & password then every git operation i have set this remote password (encrypted) in dialog.
 during every git operation (push/pull/fetch) again I have decrypted this password.
 
 **impacted fle:**  
 I have modified few functions from bellow class : saveOrUpdateGit(), pushRemote(),fetchRemote(),pullRemote(),getPassword() ,installMissingDependencies()

 meveo-admin-web/src/main/java/org/meveo/admin/action/storage/GitRepositoryBean.java
