### PR TITLE
UUID field max length increase for Sha512

### DIFF
--- a/meveo-model/src/main/java/org/meveo/model/BusinessCFEntity.java
+++ b/meveo-model/src/main/java/org/meveo/model/BusinessCFEntity.java
@@ -35,7 +35,7 @@ public abstract class BusinessCFEntity extends BusinessEntity implements ICustom
 	private static final long serialVersionUID = -6054446440106807337L;
 
 	@Column(name = "uuid", nullable = false, updatable = false, length = 60)
-	@Size(max = 60)
+	@Size(max = 128)
 	@NotNull
 	private String uuid = UUID.randomUUID().toString();
 


### PR DESCRIPTION
Textfield maxlength attribute updated for UUID field as per Sha512 character length.
   Sha512 defult lengh is 128 . So, i have updated maxlength is 128
   I have only updated this field maxlength attribute.But  not size or width of this field .

  I have updated only customEntityDetail.xhtml page UUID field. search field  already contains max length 255.

