### PR TITLE
Grid column data loading  when User a ref entity

### DIFF
--- a/meveo-admin-web/src/main/java/org/meveo/admin/action/crm/CustomFieldTemplateBean.java
+++ b/meveo-admin-web/src/main/java/org/meveo/admin/action/crm/CustomFieldTemplateBean.java
@@ -359,6 +359,13 @@ public class CustomFieldTemplateBean extends UpdateMapTypeFieldBean<CustomFieldT
         filter.setIncludeParentClassesOnly(false);
         
         List<CustomizedEntity> entities = customizedEntityService.getCustomizedEntities(filter);
+        entities.removeIf(e ->e.getEntityClass().getName().contains("org.meveo.admin.job"));
+        entities.removeIf(e ->e.getEntityClass().getName().contains("org.meveo.model.storage.BinaryStorageConfiguration")); 
+        entities.removeIf(e ->e.getEntityClass().getName().contains("org.meveo.model.filter.Filter")); 
+        entities.removeIf(e ->e.getEntityClass().getName().contains("org.meveo.model.admin.MvCredential")); 
+        entities.removeIf(e ->e.getEntityClass().getName().contains("org.meveo.model.neo4j.Neo4JConfiguration")); 
+        entities.removeIf(e ->e.getEntityClass().getName().contains("org.meveo.model.sql.SqlConfiguration"));
+        entities.removeIf(e ->e.getEntityClass().getName().contains("org.meveo.model.storage.StorageConfiguration"));
 
         for (CustomizedEntity customizedEntity : entities) {
             clazzNames.add(customizedEntity.getClassnameToDisplay());

--- a/meveo-admin-web/src/main/java/org/meveo/admin/jsf/converter/EntityReferenceConverter.java
+++ b/meveo-admin-web/src/main/java/org/meveo/admin/jsf/converter/EntityReferenceConverter.java
@@ -74,6 +74,9 @@ public class EntityReferenceConverter implements Converter<Object>, Serializable
 		if (field.getEntityClazz().equals(User.class.getName())) {
             User user = userService.findById(Long.parseLong(String.valueOf(uuid)));
             return user.getNameOrUsername();
+       }else if (field.getEntityClazz().equals(Provider.class.getName())) {
+           Provider provider = providerService.findById(Long.parseLong(String.valueOf(uuid)));
+           return provider.getCode();
        }
 		
 		String stringUuid = null;

--- a/meveo-admin-web/src/main/java/org/meveo/admin/jsf/converter/EntityReferenceConverter.java
+++ b/meveo-admin-web/src/main/java/org/meveo/admin/jsf/converter/EntityReferenceConverter.java
@@ -119,7 +119,7 @@ public class EntityReferenceConverter implements Converter<Object>, Serializable
 			}
 		}
 		
-		return null;
+		return String.valueOf(uuid);
 	}
 
 	private class FieldRepresentationLoader extends CacheLoader<String, String> {

--- a/meveo-admin-web/src/main/java/org/meveo/admin/jsf/converter/EntityReferenceConverter.java
+++ b/meveo-admin-web/src/main/java/org/meveo/admin/jsf/converter/EntityReferenceConverter.java
@@ -15,10 +15,12 @@ import javax.faces.convert.Converter;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.meveo.model.admin.User;
 import org.meveo.model.crm.CustomFieldTemplate;
 import org.meveo.model.crm.EntityReferenceWrapper;
 import org.meveo.model.crm.custom.CustomFieldTypeEnum;
 import org.meveo.model.storage.Repository;
+import org.meveo.service.admin.impl.UserService;
 import org.meveo.service.crm.impl.CustomFieldTemplateService;
 import org.meveo.service.custom.CustomTableService;
 
@@ -42,6 +44,9 @@ public class EntityReferenceConverter implements Converter<Object>, Serializable
 
 	@Inject
 	private CustomFieldTemplateService customFieldTemplateService;
+	
+	@Inject
+	private UserService userService;
 
 	private volatile Map<String, LoadingCache<String, String>> cacheMap = new HashMap<>();
 
@@ -65,6 +70,11 @@ public class EntityReferenceConverter implements Converter<Object>, Serializable
 		if (uuid == null || field.getFieldType() != CustomFieldTypeEnum.ENTITY) {
 			return null;
 		}
+		
+		if (field.getEntityClazz().equals(User.class.getName())) {
+            User user = userService.findById(Long.parseLong(String.valueOf(uuid)));
+            return user.getNameOrUsername();
+       }
 		
 		String stringUuid = null;
 		if (uuid instanceof EntityReferenceWrapper) {

--- a/meveo-admin-web/src/main/java/org/meveo/admin/jsf/converter/EntityReferenceConverter.java
+++ b/meveo-admin-web/src/main/java/org/meveo/admin/jsf/converter/EntityReferenceConverter.java
@@ -18,10 +18,12 @@ import javax.inject.Named;
 import org.meveo.model.admin.User;
 import org.meveo.model.crm.CustomFieldTemplate;
 import org.meveo.model.crm.EntityReferenceWrapper;
+import org.meveo.model.crm.Provider;
 import org.meveo.model.crm.custom.CustomFieldTypeEnum;
 import org.meveo.model.storage.Repository;
 import org.meveo.service.admin.impl.UserService;
 import org.meveo.service.crm.impl.CustomFieldTemplateService;
+import org.meveo.service.crm.impl.ProviderService;
 import org.meveo.service.custom.CustomTableService;
 
 import com.google.common.cache.CacheBuilder;
@@ -47,6 +49,9 @@ public class EntityReferenceConverter implements Converter<Object>, Serializable
 	
 	@Inject
 	private UserService userService;
+	
+	@Inject
+	private ProviderService providerService;
 
 	private volatile Map<String, LoadingCache<String, String>> cacheMap = new HashMap<>();
 


### PR DESCRIPTION
Problem : when a CET has a CFT of type user as reference of entity ,
 on that time grid summary column data is not loaded .

Root cause :
For showing data on grid ,it used <f:converter binding="#{entityReferenceConverter}" /> converter when data type is reference entity.
In this case , this converter (EntityReferenceConverter.java ) did not return any value from db (table-adm_user).
as a result this column  is  showing wrong value. 

solution : 
If CFT type is User type. in case i retrieve data from database by uuid.


 